### PR TITLE
Give Officers Roles Access

### DIFF
--- a/views/admin/home.pug
+++ b/views/admin/home.pug
@@ -22,6 +22,12 @@ html
 					div(class="content")
 						div(class="header") Blog
 						div(class="description") Post news to the homepage. Visible to anyone who vists the website.
+				if (user.level >2)
+					div(class="item")
+						i(class="large sitemap middle aligned icon")
+						div(class="content")
+							div(class="header") Roles
+							div(class="description") Manage JCR roles and assign users to positions.
 				if (user.level > 3)
 					div(class="item")
 						i(class="large ticket middle aligned icon")
@@ -43,11 +49,6 @@ html
 						div(class="content")
 							div(class="header") Room Booking
 							div(class="description") Create rooms and add bookings. Please be careful not to double book otherwise things will break.
-					div(class="item")
-						i(class="large sitemap middle aligned icon")
-						div(class="content")
-							div(class="header") Roles
-							div(class="description") Manage JCR roles and assign users to positions.
 				if (user.level > 4)
 					div(class="item")
 						i(class="large pound middle aligned icon")

--- a/views/admin/menu.pug
+++ b/views/admin/menu.pug
@@ -5,6 +5,15 @@ div(class='ui stackable small inverted menu')
 	a(class='item' href='/admin/blog')
 		i(class="newspaper icon")
 		| Blog
+	if (user.level > 2)
+		if (!user.roles[0].description)
+				a(class='item' href='/admin/roles' data-content="Your role doesn't have a description. Why not add one?" data-position="bottom center")
+					i(class="sitemap icon")
+					| Roles
+			else
+				a(class='item' href='/admin/roles')
+					i(class="sitemap icon")
+					| Roles
 	if (user.level > 3)
 		a(class='item' href='/admin/tickets')
 			i(class="ticket icon")


### PR DESCRIPTION
To encourage officers to actually write a description for their role (almost every officer currently just has 'null') it's been decided to trust officers with access to the roles admin so they can add their own description