### PR TITLE
Sync container timezone with host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     command: npm run start
     volumes:
       - ./files:/usr/app/src/public/files
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
     ports:
       - 3000:3000
     env_file: .env


### PR DESCRIPTION
Mount /etc/timezone and /etc/localtime directories as read only volumes to sync timezone with the server. Currently the docker container is on UTC instead of GMT/BST.

The problem here is that I don't this **won't work on Windows**. It works on CentOS (and most Linux distros) though which the actual server runs. I'm not sure how you guys feel about this - it would be awesome if someone had a better solution!

