### PR TITLE
Fix error and update Tech page.

### DIFF
--- a/src/views/tech/index.pug
+++ b/src/views/tech/index.pug
@@ -11,33 +11,37 @@ html
 		p
 			| The Technical Manager is responsible for all of the technical equipment
 			| in the JCR (Lighting, Audio, Staging, Power ..etc) as well as managing
-			| technical side of the
+			| the technical side of 
 			| <a href="https://greyjcr.com/files/uploaded/k-events-IRINi.doc">JCR events</a>
 
 		p
-			| The Technical Crew run the events throughout the year and anyone
-			| is welcome to join – whatever the level of experience you have. The technical crew are paid for events that they work.
+			| The Technical Crew run tech for events throughout the year and any JCR member
+			| is welcome to join – whatever their level of technical experience. Crew members are paid for events that they work.
 
 		div(class="ui vertical segment")
 			h3(class="ui header") Internal Events
 			p
 				| We also offer technical setups for Open Mic Nights & Karaoke evenings after formals. Please give a minimum of 3 weeks notice for such an 
-				| event such that approval can be obtained with college and schedule of the technical crew can be arranged. If interested in booking please contact us at: grey.tech@durham.ac.uk
+				| event so that approval can be obtained with college and a schedule for the technical crew can be arranged. If interested in booking, please contact us at: <a href="mailto:grey.tech@durham.ac.uk">grey.tech@durham.ac.uk</a>
 		div(class="ui vertical segment")
-			h3(class="ui header")Equipment Hire
+			h3(class="ui header") Equipment Hire
 			p
 				| We also hire out our equipment! Equipment can be hired for a variety
-				| of events, such as social
+				| of events, so please get in touch using the form below, or <a href="mailto:grey.tech@durham.ac.uk">by email</a>, to enquire. 
+			p
+			p(style="text-align:center;")
+				| <strong>A list of the tech available to hire can be found <a href="https://durhamtech.org.uk/grey">here</a>.</strong>
+			p
 			p
 				| Grey JCR sports and societies can hire equipment for free.
 			p
 				| <a href="https://greyjcr.com/files/uploaded/k-events-IRINi.doc">Grey JCR events</a>
 				| have priority for equipment once the event date and technical
-				| requirements from the event organiser have been confirmed, unless
+				| requirements have been confirmed with the event organiser, unless
 				| a paid hire has already been agreed. It is recommended that you contact us at the
-				| earliest point to ensure your event runs smoothly.
+				| earliest opportunity to ensure your event runs smoothly.
 			p
-				| If you have any queries, feel free to contact us.
+				| If you have any queries, feel free to <a href="mailto:grey.tech@durham.ac.uk">contact the Tech Manager</a>.
 
 		div(class="ui vertical segment")
 			iframe(width="100%"


### PR DESCRIPTION
Fixes the error that caused the Tech page to show an error message rather than the content, and also updates some of its content. In particular, I have added mailto hyperlinks for contacting the Tech Manager email address and have added a link to our hireable equipment lists. 